### PR TITLE
Bump dependencies

### DIFF
--- a/ekg-json.cabal
+++ b/ekg-json.cabal
@@ -24,10 +24,10 @@ library
   exposed-modules:
     System.Metrics.Json
   build-depends:
-    aeson >=0.4 && < 1.6,
-    base >= 4.6 && < 4.16,
+    aeson >=0.4 && < 1.6 || >= 2.0 && < 2.1,
+    base >= 4.6 && < 4.17,
     ekg-core >= 0.1 && < 0.2,
-    text < 1.3,
+    text < 1.3 || >= 2.0 && < 2.1,
     unordered-containers < 0.3
 
   default-language: Haskell2010


### PR DESCRIPTION
This is needed to successfully build the package on GHC 9.2.2, the change itself is ported from https://github.com/tibbe/ekg-json/pull/12